### PR TITLE
[Android] Fix UXCam.addTag to accept any object

### DIFF
--- a/android/src/main/java/com/rnuxcam/rnuxcam/UXCamModule.java
+++ b/android/src/main/java/com/rnuxcam/rnuxcam/UXCamModule.java
@@ -72,7 +72,7 @@ public class UXCamModule extends ReactContextBaseJavaModule {
     ReadableMapKeySetIterator iterator = properties.keySetIterator();
     while (iterator.hasNextKey()) {
       String key = iterator.nextKey();
-      String value = properties.getString(key);
+      Object value = properties.getObject(key);
       map.put(key, value);
     }
     UXCam.addTagWithProperties(tag, map);


### PR DESCRIPTION
your own example won't work on android:

UXCam.addTag('logged-in', {
  isLoggedIn: true,
  isAwesome: true,
});

it won't accept booleans  as values, just strings...



Another thing: can you update the version of uxcam?