### PR TITLE
[Android] Remove override on createJSModules for compatibility with react-native 0.47+

### DIFF
--- a/android/src/main/java/com/rnuxcam/rnuxcam/UXCamPackage.java
+++ b/android/src/main/java/com/rnuxcam/rnuxcam/UXCamPackage.java
@@ -19,7 +19,6 @@ public class UXCamPackage implements ReactPackage {
     return modules;
   }
 
-  @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
React Native release notes: https://github.com/facebook/react-native/releases/tag/v0.47.0

Keeping the method for backwards compatibility. Will release a new version 👍 