### PR TITLE
Framework search path to broad. Removed redundant search path.

### DIFF
--- a/ios/RNUXCam.xcodeproj/project.pbxproj
+++ b/ios/RNUXCam.xcodeproj/project.pbxproj
@@ -210,8 +210,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../../../ios/**",
-					"$(SRCROOT)/../../../apps/student/clients/ios/**",
+					"$(SRCROOT)/../../../ios/Pods/**"
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -231,8 +230,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../../../ios/**",
-					"$(SRCROOT)/../../../apps/student/clients/ios/**",
+					"$(SRCROOT)/../../../ios/Pods/**"
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
The previous search path was too broad. This meant that at compile time, the error "Argument list too long" presented itself. Especially if you had a reasonably deep "ios" folder.

Also removed the redundant path to a student folder.