### PR TITLE
README: Fix build.gradle location

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Run the following:
 react-native link react-native-ux-cam
 ```
 
-Then add the following to your file `android/app/build.gradle` (or add the maven url to your existing repositories section):
+Then add the following to your file `android/build.gradle` (or add the maven url to your existing repositories section):
 
 ```gradle
 repositories {


### PR DESCRIPTION
Updated location from android/app/build.gradle to android/build.gradle.